### PR TITLE
feat: Change to new version of plugin API

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     }
   },
   "dependencies": {
-    "conventional-changelog": "0.0.17"
+    "conventional-commits-parser": "^0.1.0"
   },
   "devDependencies": {
     "babel": "^5.5.8",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-const { parseRawCommit } = require('conventional-changelog/lib/git')
+const { sync as parseCommit } = require('conventional-commits-parser')
 
 module.exports = function (pluginConfig, {commit}, cb) {
-  commit = parseRawCommit(`${commit.hash}\n${commit.message}`)
+  commit = parseCommit(`${commit.hash}\n${commit.message}`)
 
   if (!commit) return cb(null, null)
   if (commit.breaks.length) return cb(null, 'major')

--- a/src/index.js
+++ b/src/index.js
@@ -1,26 +1,12 @@
 const { parseRawCommit } = require('conventional-changelog/lib/git')
 
-module.exports = function (pluginConfig, {commits}, cb) {
-  let type = null
+module.exports = function (pluginConfig, {commit}, cb) {
+  commit = parseRawCommit(`${commit.hash}\n${commit.message}`)
 
-  commits
+  if (!commit)                return cb(null, null)
+  if (commit.breaks.length)   return cb(null, 'major')
+  if (commit.type === 'feat') return cb(null, 'minor')
+  if (commit.type === 'fix')  return cb(null, 'patch')
 
-  .map((commit) => parseRawCommit(`${commit.hash}\n${commit.message}`))
-
-  .filter((commit) => !!commit)
-
-  .every((commit) => {
-    if (commit.breaks.length) {
-      type = 'major'
-      return false
-    }
-
-    if (commit.type === 'feat') type = 'minor'
-
-    if (!type && commit.type === 'fix') type = 'patch'
-
-    return true
-  })
-
-  cb(null, type)
+  cb(null, null)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,10 @@ const { parseRawCommit } = require('conventional-changelog/lib/git')
 module.exports = function (pluginConfig, {commit}, cb) {
   commit = parseRawCommit(`${commit.hash}\n${commit.message}`)
 
-  if (!commit)                return cb(null, null)
-  if (commit.breaks.length)   return cb(null, 'major')
+  if (!commit) return cb(null, null)
+  if (commit.breaks.length) return cb(null, 'major')
   if (commit.type === 'feat') return cb(null, 'minor')
-  if (commit.type === 'fix')  return cb(null, 'patch')
+  if (commit.type === 'fix') return cb(null, 'patch')
 
   cb(null, null)
 }

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -7,10 +7,10 @@ test('derive version number from commits', (t) => {
     tt.plan(2)
 
     analyzer({}, {
-      commits: [{
-        hash: 'asdf',
+      commit: {
+        hash: '1234',
         message: 'chore: build script'
-      }]
+      }
     }, (err, type) => {
       tt.error(err)
       tt.is(type, null)
@@ -21,13 +21,10 @@ test('derive version number from commits', (t) => {
     tt.plan(2)
 
     analyzer({}, {
-      commits: [{
-        hash: 'asdf',
-        message: 'fix: nasty bug'
-      }, {
+      commit: {
         hash: '1234',
         message: 'fix(scope): even nastier bug'
-      }]
+      }
     }, (err, type) => {
       tt.error(err)
       tt.is(type, 'patch')
@@ -38,13 +35,10 @@ test('derive version number from commits', (t) => {
     tt.plan(2)
 
     analyzer({}, {
-      commits: [{
-        hash: 'asdf',
-        message: 'fix: nasty bug'
-      }, {
+      commit: {
         hash: '1234',
         message: 'feat(scope): cool feature'
-      }]
+      }
     }, (err, type) => {
       tt.error(err)
       tt.is(type, 'minor')
@@ -55,16 +49,10 @@ test('derive version number from commits', (t) => {
     tt.plan(2)
 
     analyzer({}, {
-      commits: [{
-        hash: 'qwer',
-        message: 'feat(something): even cooler feature\nBREAKING CHANGE: everything so broken'
-      }, {
+      commit: {
         hash: '1234',
-        message: 'feat(scope): cool feature'
-      }, {
-        hash: 'asdf',
-        message: 'fix: nasty bug'
-      }]
+        message: 'feat(something): even cooler feature\nBREAKING CHANGE: everything so broken'
+      }
     }, (err, type) => {
       tt.error(err)
       tt.is(type, 'major')


### PR DESCRIPTION
Change to the new version of the commit analyzer API. Now the parser is called
multiple times with only a single commit each time, and semantic-release takes
care of keeping track of the version. This drastically simplifies the code.

BREAKING CHANGE:
    Instead of accepting an array of commits with the `commits` option, we now
    accept a single commit with the `commit` option. Use that instead, and call
    the plugin multiple times.
