### PR TITLE
Add [release skip] command

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const { parseRawCommit } = require('conventional-changelog/lib/git')
 module.exports = function (pluginConfig, {commit}, cb) {
   if (commit.message.indexOf('[release skip]') > -1 ||
       commit.message.indexOf('[skip release]') > -1) {
-    return cb(null, null)
+    return cb(null, 'rskip')
   }
 
   commit = parseRawCommit(`${commit.hash}\n${commit.message}`)

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,11 @@
 const { parseRawCommit } = require('conventional-changelog/lib/git')
 
 module.exports = function (pluginConfig, {commit}, cb) {
+  if (commit.message.indexOf('[release skip]') > -1 ||
+      commit.message.indexOf('[skip release]') > -1 ){
+    return cb(null, null)
+  }
+
   commit = parseRawCommit(`${commit.hash}\n${commit.message}`)
 
   if (!commit) return cb(null, null)

--- a/src/index.js
+++ b/src/index.js
@@ -1,26 +1,12 @@
 const { parseRawCommit } = require('conventional-changelog/lib/git')
 
-module.exports = function (pluginConfig, {commits}, cb) {
-  let type = null
+module.exports = function (pluginConfig, {commit}, cb) {
+  commit = parseRawCommit(`${commit.hash}\n${commit.message}`)
 
-  commits
+  if (!commit)                return cb(null, null)
+  if (commit.breaks.length)   return cb(null, 'major')
+  if (commit.type === 'feat') return cb(null, 'minor')
+  if (commit.type === 'fix')  return cb(null, 'patch')
 
-  .map((commit) => parseRawCommit(`${commit.hash}\n${commit.message}`))
-
-  .filter((commit) => !!commit)
-
-  .every((commit) => {
-    if (commit.breaks.length) {
-      type = 'major'
-      return false
-    }
-
-    if (commit.type === 'feat') type = 'minor'
-
-    if (!type && commit.type === 'fix') type = 'patch'
-
-    return true
-  })
-
-  cb(null, type)
+  cb(null, null)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const { parseRawCommit } = require('conventional-changelog/lib/git')
 
 module.exports = function (pluginConfig, {commit}, cb) {
   if (commit.message.indexOf('[release skip]') > -1 ||
-      commit.message.indexOf('[skip release]') > -1 ){
+      commit.message.indexOf('[skip release]') > -1) {
     return cb(null, null)
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,10 @@ const { parseRawCommit } = require('conventional-changelog/lib/git')
 module.exports = function (pluginConfig, {commit}, cb) {
   commit = parseRawCommit(`${commit.hash}\n${commit.message}`)
 
-  if (!commit)                return cb(null, null)
-  if (commit.breaks.length)   return cb(null, 'major')
+  if (!commit) return cb(null, null)
+  if (commit.breaks.length) return cb(null, 'major')
   if (commit.type === 'feat') return cb(null, 'minor')
-  if (commit.type === 'fix')  return cb(null, 'patch')
+  if (commit.type === 'fix') return cb(null, 'patch')
 
   cb(null, null)
 }

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -7,10 +7,10 @@ test('derive version number from commits', (t) => {
     tt.plan(2)
 
     analyzer({}, {
-      commits: [{
-        hash: 'asdf',
+      commit: {
+        hash: '1234',
         message: 'chore: build script'
-      }]
+      }
     }, (err, type) => {
       tt.error(err)
       tt.is(type, null)
@@ -21,13 +21,10 @@ test('derive version number from commits', (t) => {
     tt.plan(2)
 
     analyzer({}, {
-      commits: [{
-        hash: 'asdf',
-        message: 'fix: nasty bug'
-      }, {
+      commit: {
         hash: '1234',
         message: 'fix(scope): even nastier bug'
-      }]
+      }
     }, (err, type) => {
       tt.error(err)
       tt.is(type, 'patch')
@@ -38,13 +35,10 @@ test('derive version number from commits', (t) => {
     tt.plan(2)
 
     analyzer({}, {
-      commits: [{
-        hash: 'asdf',
-        message: 'fix: nasty bug'
-      }, {
+      commit: {
         hash: '1234',
         message: 'feat(scope): cool feature'
-      }]
+      }
     }, (err, type) => {
       tt.error(err)
       tt.is(type, 'minor')
@@ -55,16 +49,10 @@ test('derive version number from commits', (t) => {
     tt.plan(2)
 
     analyzer({}, {
-      commits: [{
-        hash: 'qwer',
-        message: 'feat(something): even cooler feature\nBREAKING CHANGE: everything so broken'
-      }, {
+      commit: {
         hash: '1234',
-        message: 'feat(scope): cool feature'
-      }, {
-        hash: 'asdf',
-        message: 'fix: nasty bug'
-      }]
+        message: 'feat(something): even cooler feature\nBREAKING CHANGE: everything so broken'
+      }
     }, (err, type) => {
       tt.error(err)
       tt.is(type, 'major')

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -3,6 +3,8 @@ const { test } = require('tap')
 const analyzer = require('../../dist')
 
 test('derive version number from commits', (t) => {
+  t.plan(5)
+
   t.test('no change', (tt) => {
     tt.plan(2)
 
@@ -56,6 +58,34 @@ test('derive version number from commits', (t) => {
     }, (err, type) => {
       tt.error(err)
       tt.is(type, 'major')
+    })
+  })
+
+  t.test('[release skip]', (tt) => {
+    tt.plan(2)
+
+    analyzer({}, {
+      commit: {
+        hash: '1234',
+        message: 'feat(something): even cooler feature\n[release skip]'
+      }
+    }, (err, type) => {
+      tt.error(err)
+      tt.is(type, 'rskip')
+    })
+  })
+
+  t.test('[skip release]', (tt) => {
+    tt.plan(2)
+
+    analyzer({}, {
+      commit: {
+        hash: '1234',
+        message: 'feat(something): even cooler feature\n[skip release]'
+      }
+    }, (err, type) => {
+      tt.error(err)
+      tt.is(type, 'rskip')
     })
   })
 


### PR DESCRIPTION
Title basically says it all.

If `[release skip]` or `[skip release]` are in the commit message.

Note that it only works if it is the most recent commit that contains the command.

Fixes semantic-release/semantic-release#41
