### PR TITLE
fix: add more patch version types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,24 @@
 [![Dependency Status](https://david-dm.org/semantic-release/commit-analyzer.svg)](https://david-dm.org/semantic-release/commit-analyzer)
 [![devDependency Status](https://david-dm.org/semantic-release/commit-analyzer/dev-status.svg)](https://david-dm.org/semantic-release/commit-analyzer#info=devDependencies)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://github.com/feross/standard)
+
+## Major Releases
+
+- Breaking Changes
+
+## Minor Releases
+
+- feat
+
+SEE: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#type
+
+## Patch Releases
+
+- chore
+- docs
+- fix
+- perf
+- refactor
+- test
+
+SEE: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#type

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,13 @@
 const { parseRawCommit } = require('conventional-changelog/lib/git')
+const typeMap = {
+  chore: 'patch',
+  docs: 'patch',
+  feat: 'minor',
+  fix: 'patch',
+  perf: 'patch',
+  refactor: 'patch',
+  test: 'patch'
+}
 
 module.exports = function (pluginConfig, {commits}, cb) {
   let type = null
@@ -15,9 +24,9 @@ module.exports = function (pluginConfig, {commits}, cb) {
       return false
     }
 
-    if (commit.type === 'feat') type = 'minor'
-
-    if (!type && commit.type === 'fix') type = 'patch'
+    if (commit.type in typeMap) {
+      type = typeMap[commit.type]
+    }
 
     return true
   })

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -3,13 +3,13 @@ const { test } = require('tap')
 const analyzer = require('../../dist')
 
 test('derive version number from commits', (t) => {
-  t.test('no change', (tt) => {
+  t.test('style -> no release', (tt) => {
     tt.plan(2)
 
     analyzer({}, {
       commits: [{
         hash: 'asdf',
-        message: 'chore: build script'
+        message: 'style: switch to JS standard style'
       }]
     }, (err, type) => {
       tt.error(err)
@@ -17,7 +17,49 @@ test('derive version number from commits', (t) => {
     })
   })
 
-  t.test('patch version', (tt) => {
+  t.test('chore -> patch release', (tt) => {
+    tt.plan(2)
+
+    analyzer({}, {
+      commits: [{
+        hash: 'asdf',
+        message: 'chore(travis): add email notifications'
+      }]
+    }, (err, type) => {
+      tt.error(err)
+      tt.is(type, 'patch')
+    })
+  })
+
+  t.test('docs -> patch release', (tt) => {
+    tt.plan(2)
+
+    analyzer({}, {
+      commits: [{
+        hash: 'asdf',
+        message: 'docs(badges): add standard badge'
+      }]
+    }, (err, type) => {
+      tt.error(err)
+      tt.is(type, 'patch')
+    })
+  })
+
+  t.test('perf -> patch release', (tt) => {
+    tt.plan(2)
+
+    analyzer({}, {
+      commits: [{
+        hash: 'asdf',
+        message: 'perf: v8 is awesome'
+      }]
+    }, (err, type) => {
+      tt.error(err)
+      tt.is(type, 'patch')
+    })
+  })
+
+  t.test('fix -> patch release', (tt) => {
     tt.plan(2)
 
     analyzer({}, {
@@ -27,6 +69,20 @@ test('derive version number from commits', (t) => {
       }, {
         hash: '1234',
         message: 'fix(scope): even nastier bug'
+      }]
+    }, (err, type) => {
+      tt.error(err)
+      tt.is(type, 'patch')
+    })
+  })
+
+  t.test('refactor -> patch release', (tt) => {
+    tt.plan(2)
+
+    analyzer({}, {
+      commits: [{
+        hash: 'asdf',
+        message: 'refactor: drop constructors, use functions & delegation'
       }]
     }, (err, type) => {
       tt.error(err)


### PR DESCRIPTION
add chore, docs, perf, refactor, and test as patch releases.
closes #3
